### PR TITLE
fixed MultiplyBatteryLevel error message

### DIFF
--- a/RFXCOM.indigoPlugin/Contents/Info.plist
+++ b/RFXCOM.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2.1.12</string>
+	<string>2.1.13</string>
 	<key>ServerApiVersion</key>
 	<string>2.0.0</string>
 	<key>IwsApiVersion</key>

--- a/RFXCOM.indigoPlugin/Contents/Server Plugin/RFXTRX.py
+++ b/RFXCOM.indigoPlugin/Contents/Server Plugin/RFXTRX.py
@@ -1511,7 +1511,7 @@ class RFXTRX(object):
 		if sensor in self.devicesCopy.keys():
 			self.plugin.debugLog(u"Temp sensor %d in list" % sensor)
 			
-			if self.devicesCopy[sensor].pluginProps['MultiplyBatteryLevel']:
+			if 'MultiplyBatteryLevel' in self.devicesCopy[sensor].pluginProps and self.devicesCopy[sensor].pluginProps['MultiplyBatteryLevel']:
 				batteryLevel *= 10
 				if batteryLevel > 100:
 					batteryLevel = 100	


### PR DESCRIPTION
added
if 'MultiplyBatteryLevel' in self.devicesCopy[sensor].pluginProps and ..

to capture missing property